### PR TITLE
Example overriding OSGi resource bundles

### DIFF
--- a/maven/blade.hook.resourcebundle/bnd.bnd
+++ b/maven/blade.hook.resourcebundle/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-SymbolicName: blade.hook.resource.bundle
+Bundle-Version: 1.0.0
+Provide-Capability:\
+	liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+	liferay.resource.bundle;resource.bundle.aggregate="(bundle.symbolic.name=blade.hook.resource.bundle),(&(!(resource.bundle.aggregate=*))(bundle.symbolic.name=com.liferay.blogs.web))";bundle.symbolic.name=com.liferay.blogs.web;resource.bundle.base.name="content.Language";service.ranking=0;servlet.context.name=blogs-web
+Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=com.liferay.blogs.web)"

--- a/maven/blade.hook.resourcebundle/bnd.bnd
+++ b/maven/blade.hook.resourcebundle/bnd.bnd
@@ -1,6 +1,2 @@
 Bundle-SymbolicName: blade.hook.resource.bundle
 Bundle-Version: 1.0.0
-Provide-Capability:\
-	liferay.resource.bundle;resource.bundle.base.name="content.Language",\
-	liferay.resource.bundle;resource.bundle.aggregate="(bundle.symbolic.name=blade.hook.resource.bundle),(&(!(resource.bundle.aggregate=*))(bundle.symbolic.name=com.liferay.blogs.web))";bundle.symbolic.name=com.liferay.blogs.web;resource.bundle.base.name="content.Language";service.ranking=0;servlet.context.name=blogs-web
-Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=com.liferay.blogs.web)"

--- a/maven/blade.hook.resourcebundle/pom.xml
+++ b/maven/blade.hook.resourcebundle/pom.xml
@@ -1,0 +1,19 @@
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>blade.hook.resourcebundle</artifactId>
+	<name>BLADE Hook Resource Bundle</name>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+
+	<parent>
+		<groupId>blade</groupId>
+		<artifactId>blade.parent.bnd.bundle.plugin</artifactId>
+		<version>1.0.0</version>
+		<relativePath>../parent.bnd.bundle.plugin</relativePath>
+	</parent>
+</project>

--- a/maven/blade.hook.resourcebundle/pom.xml
+++ b/maven/blade.hook.resourcebundle/pom.xml
@@ -8,6 +8,18 @@
 	<artifactId>blade.hook.resourcebundle</artifactId>
 	<name>BLADE Hook Resource Bundle</name>
 	<version>1.0.0</version>
+	<dependencies>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>com.liferay.portal.kernel</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.compendium</artifactId>
+			<version>5.0.0</version>
+		</dependency>
+	</dependencies>
 	<packaging>jar</packaging>
 
 	<parent>

--- a/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
+++ b/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
@@ -40,7 +40,7 @@ public class ResourceBundleLoaderComponent implements ResourceBundleLoader {
 		return _resourceBundleLoader.loadResourceBundle(languageId);
 	}
 
-	@Reference(target = "(&(!(resource.bundle.aggregate=*))(bundle.symbolic.name=com.liferay.blogs.web))")
+	@Reference(target = "(bundle.symbolic.name=com.liferay.blogs.web)")
 	public void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 

--- a/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
+++ b/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package blade.hook.resourcebundle;
+
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.ResourceBundle;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+@Component(
+	immediate = true,
+	property = {
+		"bundle.symbolic.name=com.liferay.blogs.web",
+		"resource.bundle.base.name=content.Language",
+		"servlet.context.name=blogs-web"
+	})
+public class ResourceBundleLoaderComponent implements ResourceBundleLoader {
+
+	@Override
+	public ResourceBundle loadResourceBundle(String languageId) {
+		return _resourceBundleLoader.loadResourceBundle(languageId);
+	}
+
+	@Reference(target = "(&(!(resource.bundle.aggregate=*))(bundle.symbolic.name=com.liferay.blogs.web))")
+	public void setResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
+
+		_resourceBundleLoader = new AggregateResourceBundleLoader(
+			ResourceBundleUtil.getResourceBundleLoader(
+				"content.Language",
+				ResourceBundleLoaderComponent.class.getClassLoader()),
+			resourceBundleLoader);
+	}
+
+	private AggregateResourceBundleLoader _resourceBundleLoader;
+
+}

--- a/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
+++ b/maven/blade.hook.resourcebundle/src/main/java/blade/hook/resourcebundle/ResourceBundleLoaderComponent.java
@@ -15,8 +15,9 @@
 package blade.hook.resourcebundle;
 
 import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
+import com.liferay.portal.kernel.util.CacheResourceBundleLoader;
+import com.liferay.portal.kernel.util.ClassResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,9 +46,10 @@ public class ResourceBundleLoaderComponent implements ResourceBundleLoader {
 		ResourceBundleLoader resourceBundleLoader) {
 
 		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			ResourceBundleUtil.getResourceBundleLoader(
-				"content.Language",
-				ResourceBundleLoaderComponent.class.getClassLoader()),
+			new CacheResourceBundleLoader(
+				new ClassResourceBundleLoader(
+					"content.Language",
+					ResourceBundleLoaderComponent.class.getClassLoader())),
 			resourceBundleLoader);
 	}
 

--- a/maven/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
+++ b/maven/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
@@ -1,0 +1,1 @@
+add-blog-entry=Overriden Add Blog Entry

--- a/maven/blade.hook.resourcebundle/src/main/resources/content/Language_es.properties
+++ b/maven/blade.hook.resourcebundle/src/main/resources/content/Language_es.properties
@@ -1,0 +1,1 @@
+add-blog-entry=Añadir entrada sobreescrita


### PR DESCRIPTION
This is an example on how to override the keys of portlets, taglibs or javascript and css from OSGi 